### PR TITLE
add linux flags to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
+# compiler flags
+FLAGS := -lSDL2main -lSDL2 -lSDL2_ttf -lSDL2_image -lm
+EXEC := cave-of-grell
+
+# detect windows
+ifeq ($(OS),Windows_NT)
+	FLAGS := -I"C:\libsdl\include" -L"C:\libsdl\lib" -lmingw32 -lSDL2main -lSDL2 -lSDL2_ttf -lSDL2_image
+	EXEC := cave-of-grell.exe
+endif
+
 build:
 	gcc -Wall \
 	-std=c99 \
 	./main.c \
-	-I"C:\libsdl\include" \
-	-L"C:\libsdl\lib" \
-	-lmingw32 \
-	-lSDL2main \
-	-lSDL2 \
-	-lSDL2_ttf \
-	-lSDL2_image \
-	-o main.exe
+	$(FLAGS) \
+	-o $(EXEC)


### PR DESCRIPTION
uses a separate FLAGS variable which holds specific compiler flags for windows and non-windows platforms. the `ifeq` detects whether the OS is Windows (untested) and if it does it uses the same flags as in the original Makefile. otherwise, it uses the flags you need to build on Linux (and I'm assuming this probably works on Mac too).